### PR TITLE
FIX #56 go2nix can sometimes skips packages

### DIFF
--- a/save.go
+++ b/save.go
@@ -202,8 +202,7 @@ func (c *context) find(name string, testImports bool) error {
 	if name != "." {
 		c.soFar[pkg.ImportPath] = true
 	}
-
-	if strings.Contains(c.dir, "/vendor") {
+	if strings.Contains(c.dir, "/vendor") && !strings.HasSuffix(c.dir, "/vendor") {
 		return nil
 	}
 


### PR DESCRIPTION
processed after analyzing vendored subtree